### PR TITLE
Migrate to new ortp and bctoolbox

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,9 @@ CFLAGS += -MMD -Wall
 LDLIBS_ASOUND ?= -lasound
 LDLIBS_OPUS ?= -lopus
 LDLIBS_ORTP ?= -lortp
+LDLIBS_BCTOOLBOX ?= -lbctoolbox
 
-LDLIBS += $(LDLIBS_ASOUND) $(LDLIBS_OPUS) $(LDLIBS_ORTP)
+LDLIBS += $(LDLIBS_ASOUND) $(LDLIBS_OPUS) $(LDLIBS_ORTP) $(LDLIBS_BCTOOLBOX)
 
 .PHONY:		all install dist clean
 

--- a/rx.c
+++ b/rx.c
@@ -32,7 +32,7 @@
 
 static unsigned int verbose = DEFAULT_VERBOSE;
 
-static void timestamp_jump(RtpSession *session, ...)
+static void timestamp_jump(RtpSession *session, void *arg1, void *arg2, void *arg3)
 {
 	if (verbose > 1)
 		fputc('|', stderr);

--- a/tx.c
+++ b/tx.c
@@ -240,7 +240,7 @@ int main(int argc, char *argv[])
 
 	ortp_init();
 	ortp_scheduler_init();
-	ortp_set_log_level_mask(ORTP_WARNING|ORTP_ERROR);
+	ortp_set_log_level_mask(NULL, ORTP_WARNING|ORTP_ERROR);
 	session = create_rtp_send(addr, port);
 	assert(session != NULL);
 


### PR DESCRIPTION
Updated trx to work with new (2018) versions of ortp and bctoolbox